### PR TITLE
Update index.html

### DIFF
--- a/H5/index.html
+++ b/H5/index.html
@@ -428,6 +428,11 @@
 				}).fail(function(){
 					$("body").unmask();
 					$.gritter.add(msg);
+					//2017-2-10 哈 当请求流失败时应当关闭流推送
+					$.ajax({
+						type : "GET",
+						url : _url + "/stopdevicestream?" + params.join("&")
+					});
 				})
 			})
 		})


### PR DESCRIPTION
启动流推送后，可能应各种原因拿不到流，此时在失败时应该关闭流推送以保证服务的正常运行